### PR TITLE
Feat/request ledger

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth-ktx:20.0.4'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.1'
     implementation 'com.android.volley:volley:1.2.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/com/example/masterproject/BroadcastMessageTypes.kt
+++ b/app/src/main/java/com/example/masterproject/BroadcastMessageTypes.kt
@@ -1,5 +1,8 @@
 package com.example.masterproject
 
 enum class BroadcastMessageTypes {
-    BROADCAST_LEDGER
+    BROADCAST_BLOCK,
+    REQUEST_LEDGER,
+    FULL_LEDGER,
+    LEDGER_HASH
 }

--- a/app/src/main/java/com/example/masterproject/BroadcastMessageTypes.kt
+++ b/app/src/main/java/com/example/masterproject/BroadcastMessageTypes.kt
@@ -1,0 +1,5 @@
+package com.example.masterproject
+
+enum class BroadcastMessageTypes {
+    BROADCAST_LEDGER
+}

--- a/app/src/main/java/com/example/masterproject/LedgerEntry.kt
+++ b/app/src/main/java/com/example/masterproject/LedgerEntry.kt
@@ -1,6 +1,22 @@
 package com.example.masterproject
 
+import android.util.Log
+import org.json.JSONObject
+import org.json.JSONTokener
 import java.security.cert.X509Certificate
 
 data class LedgerEntry(val certificate: X509Certificate, val userName: String, val ipAddress: String = "") {
+
+    override fun toString(): String {
+        return "{\"username\":\"$userName\",\"ipAddress\":\"$ipAddress\",\"certificate\":\"${Utils.certificateToString(certificate)}\"}"
+    }
+
+    companion object {
+        private val TAG = "LedgerEntry"
+        fun parseString(ledgerEntry: String): LedgerEntry {
+            val jsonObject = JSONTokener(ledgerEntry).nextValue() as JSONObject
+            Log.d(TAG, jsonObject.toString())
+            return LedgerEntry(Utils.stringToCertificate(jsonObject.getString("certificate")), jsonObject.getString("username"), jsonObject.getString("ipAddress"))
+        }
+    }
 }

--- a/app/src/main/java/com/example/masterproject/MainActivity.kt
+++ b/app/src/main/java/com/example/masterproject/MainActivity.kt
@@ -21,6 +21,9 @@ import android.widget.Toast
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 
 class MainActivity: AppCompatActivity() {
@@ -60,10 +63,13 @@ class MainActivity: AppCompatActivity() {
         }
         Utils.myLedgerEntry = LedgerEntry(Utils.getCertificate()!!, username)
 
+        val multicastClient = MulticastClient(multicastGroup, multicastPort)
+        GlobalScope.launch(Dispatchers.IO) {
+            multicastClient.broadcastBlock()
+        }
+
         //Start network processes
-        val multicastClientThread = MulticastClient(multicastGroup, multicastPort)
         Thread(multicastServerThread).start()
-        Thread(multicastClientThread).start()
         val tcpServerThread = TCPServer(findViewById(R.id.tcpMessage))
         Thread(tcpServerThread).start()
 

--- a/app/src/main/java/com/example/masterproject/MainActivity.kt
+++ b/app/src/main/java/com/example/masterproject/MainActivity.kt
@@ -12,11 +12,6 @@ import com.example.masterproject.Ledger.Companion.availableDevices
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.Security
 import android.content.Intent
-import android.net.ConnectivityManager
-import android.net.LinkProperties
-import android.net.Network
-import android.net.NetworkCapabilities
-import android.util.Log
 import android.widget.Toast
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -63,7 +58,7 @@ class MainActivity: AppCompatActivity() {
         }
         val myLedgerEntry = LedgerEntry(Utils.getCertificate()!!, username)
         Utils.myLedgerEntry = myLedgerEntry
-        //availableDevices.add(myLedgerEntry)
+        availableDevices.add(myLedgerEntry)
 
         val multicastClient = MulticastClient(multicastGroup, multicastPort)
         GlobalScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/example/masterproject/MainActivity.kt
+++ b/app/src/main/java/com/example/masterproject/MainActivity.kt
@@ -12,6 +12,11 @@ import com.example.masterproject.Ledger.Companion.availableDevices
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.Security
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.util.Log
 import android.widget.Toast
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -25,6 +30,9 @@ class MainActivity: AppCompatActivity() {
     private val multicastPort: Int = 8888
     private val multicastServerThread = MulticastServer(multicastGroup, multicastPort)
     private lateinit var auth: FirebaseAuth
+
+    private val TAG = "MainActivity"
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,10 +57,6 @@ class MainActivity: AppCompatActivity() {
             Utils.storePrivateKey(keyPair.private, this)
             val certificate = Utils.generateSelfSignedX509Certificate(username, keyPair)
             Utils.storeCertificate(certificate, this)
-        }
-        else {
-            username = Utils.getUsernameFromCertificate(storedCertificate)
-            Utils.fetchStoredPrivateKey(this)
         }
         Utils.myLedgerEntry = LedgerEntry(Utils.getCertificate()!!, username)
 

--- a/app/src/main/java/com/example/masterproject/MainActivity.kt
+++ b/app/src/main/java/com/example/masterproject/MainActivity.kt
@@ -61,11 +61,17 @@ class MainActivity: AppCompatActivity() {
             val certificate = Utils.generateSelfSignedX509Certificate(username, keyPair)
             Utils.storeCertificate(certificate, this)
         }
-        Utils.myLedgerEntry = LedgerEntry(Utils.getCertificate()!!, username)
+        val myLedgerEntry = LedgerEntry(Utils.getCertificate()!!, username)
+        Utils.myLedgerEntry = myLedgerEntry
+        //availableDevices.add(myLedgerEntry)
 
         val multicastClient = MulticastClient(multicastGroup, multicastPort)
         GlobalScope.launch(Dispatchers.IO) {
             multicastClient.broadcastBlock()
+        }
+
+        GlobalScope.launch(Dispatchers.IO) {
+            multicastClient.requestLedger()
         }
 
         //Start network processes

--- a/app/src/main/java/com/example/masterproject/MulticastClient.kt
+++ b/app/src/main/java/com/example/masterproject/MulticastClient.kt
@@ -1,5 +1,6 @@
 package com.example.masterproject
 
+import android.provider.ContactsContract
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,7 +25,7 @@ class MulticastClient(private val multicastGroup: String, private val multicastP
             var msgPacket = DatagramPacket(msg.toByteArray(), msg.toByteArray().size, addr, multicastPort)
             serverSocket.send(msgPacket);
             serverSocket.close()
-            Log.d(TAG,"Multicast packet sent")
+            Log.d(TAG,msg)
         }catch (e: Exception) {
             e.printStackTrace()
         }
@@ -33,10 +34,27 @@ class MulticastClient(private val multicastGroup: String, private val multicastP
 
     suspend fun broadcastBlock(): Void? {
         val jsonObject = JSONObject()
-        jsonObject.put("type", BroadcastMessageTypes.BROADCAST_LEDGER)
+        jsonObject.put("type", BroadcastMessageTypes.BROADCAST_BLOCK)
         jsonObject.put("username", Utils.myLedgerEntry!!.userName)
         jsonObject.put("ipAddress", Utils.getMyIpAddress())
         jsonObject.put("certificate", Utils.certificateToString(Utils.myLedgerEntry!!.certificate))
+        return withContext(Dispatchers.IO) {
+            sendMulticastData(jsonObject.toString())
+        }
+    }
+
+    suspend fun requestLedger(): Void? {
+        val jsonObject = JSONObject()
+        jsonObject.put("type", BroadcastMessageTypes.REQUEST_LEDGER)
+        return withContext(Dispatchers.IO) {
+            sendMulticastData(jsonObject.toString())
+        }
+    }
+
+    suspend fun sendLedger(): Void? {
+        val jsonObject = JSONObject()
+        jsonObject.put("type", BroadcastMessageTypes.FULL_LEDGER)
+        jsonObject.put("ledger", Ledger.availableDevices.map {it.toString()})
         return withContext(Dispatchers.IO) {
             sendMulticastData(jsonObject.toString())
         }

--- a/app/src/main/java/com/example/masterproject/MulticastClient.kt
+++ b/app/src/main/java/com/example/masterproject/MulticastClient.kt
@@ -1,6 +1,8 @@
 package com.example.masterproject
 
 import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.lang.Exception
 import java.lang.StringBuilder
@@ -11,7 +13,7 @@ import java.security.PublicKey
 import java.security.spec.X509EncodedKeySpec
 import java.util.*
 
-class MulticastClient(private val multicastGroup: String, private val multicastPort: Int): Runnable {
+class MulticastClient(private val multicastGroup: String, private val multicastPort: Int) {
 
     private val TAG = "MulticastClient"
 
@@ -29,28 +31,15 @@ class MulticastClient(private val multicastGroup: String, private val multicastP
         return null;
     }
 
-    private fun broadcastBlock(): Void? {
+    suspend fun broadcastBlock(): Void? {
         val jsonObject = JSONObject()
         jsonObject.put("type", BroadcastMessageTypes.BROADCAST_LEDGER)
         jsonObject.put("username", Utils.myLedgerEntry!!.userName)
         jsonObject.put("ipAddress", Utils.getMyIpAddress())
         jsonObject.put("certificate", Utils.certificateToString(Utils.myLedgerEntry!!.certificate))
-        return sendMulticastData(jsonObject.toString())
-    }
-
-    override fun run() {
-        try{
-            while (true){
-                if(Utils.myLedgerEntry != null){
-                    broadcastBlock()
-                }
-                Thread.sleep(2000)
-            }
-        }catch (e:Exception){
-            e.printStackTrace()
+        return withContext(Dispatchers.IO) {
+            sendMulticastData(jsonObject.toString())
         }
     }
-
-
 
 }

--- a/app/src/main/java/com/example/masterproject/MulticastClient.kt
+++ b/app/src/main/java/com/example/masterproject/MulticastClient.kt
@@ -13,34 +13,36 @@ import java.util.*
 
 class MulticastClient(private val multicastGroup: String, private val multicastPort: Int): Runnable {
 
-    private fun sendMulticastData(): Void? {
+    private val TAG = "MulticastClient"
+
+    private fun sendMulticastData(msg: String): Void? {
         var addr = InetAddress.getByName(multicastGroup)
         try {
             var serverSocket = DatagramSocket()
-            var msg = createMulticastMessage()
             var msgPacket = DatagramPacket(msg.toByteArray(), msg.toByteArray().size, addr, multicastPort)
             serverSocket.send(msgPacket);
             serverSocket.close()
-            //Log.d("DEBUG SIGMUND","Multicast packet sendt")
+            Log.d(TAG,"Multicast packet sent")
         }catch (e: Exception) {
             e.printStackTrace()
         }
         return null;
     }
 
-    private fun createMulticastMessage(): String {
+    private fun broadcastBlock(): Void? {
         val jsonObject = JSONObject()
+        jsonObject.put("type", BroadcastMessageTypes.BROADCAST_LEDGER)
         jsonObject.put("username", Utils.myLedgerEntry!!.userName)
         jsonObject.put("ipAddress", Utils.getMyIpAddress())
         jsonObject.put("certificate", Utils.certificateToString(Utils.myLedgerEntry!!.certificate))
-        return jsonObject.toString()
+        return sendMulticastData(jsonObject.toString())
     }
 
     override fun run() {
         try{
             while (true){
                 if(Utils.myLedgerEntry != null){
-                    sendMulticastData()
+                    broadcastBlock()
                 }
                 Thread.sleep(2000)
             }

--- a/app/src/main/java/com/example/masterproject/MulticastServer.kt
+++ b/app/src/main/java/com/example/masterproject/MulticastServer.kt
@@ -10,6 +10,8 @@ import java.net.MulticastSocket
 
 class MulticastServer(private val multicastGroup: String, private val multicastPort: Int): Runnable {
 
+    private val TAG = "MutlicastServer"
+
     private fun listenForDevices(): MutableList<LedgerEntry>? {
         val address = InetAddress.getByName(multicastGroup);
         val buf = ByteArray(512)
@@ -24,13 +26,15 @@ class MulticastServer(private val multicastGroup: String, private val multicastP
                 val msgRaw = String(buf, 0, buf.size)
                 //Log.d("SIGMUND TEST",msgRaw)
                 val jsonObject = JSONObject(msgRaw)
-                val username = jsonObject.getString("username")
-                val certificateString = jsonObject.getString("certificate")
-                val ipAddress = jsonObject.getString("ipAddress")
-                val ledgerEntry = LedgerEntry(Utils.stringToCertificate(certificateString), username, ipAddress)
+                if (jsonObject.getString("type") == BroadcastMessageTypes.BROADCAST_LEDGER.toString()) {
+                    val username = jsonObject.getString("username")
+                    val certificateString = jsonObject.getString("certificate")
+                    val ipAddress = jsonObject.getString("ipAddress")
+                    val ledgerEntry = LedgerEntry(Utils.stringToCertificate(certificateString), username, ipAddress)
 
-                if(isAddEntryToLedger(ledgerEntry)){
-                    Ledger.availableDevices.add(ledgerEntry)
+                    if(isAddEntryToLedger(ledgerEntry)){
+                        Ledger.availableDevices.add(ledgerEntry)
+                    }
                 }
             }
         }catch (e: Exception){

--- a/app/src/main/java/com/example/masterproject/MulticastServer.kt
+++ b/app/src/main/java/com/example/masterproject/MulticastServer.kt
@@ -24,7 +24,7 @@ class MulticastServer(private val multicastGroup: String, private val multicastP
                 clientSocket.receive(msgPacket);
 
                 val msgRaw = String(buf, 0, buf.size)
-                //Log.d("SIGMUND TEST",msgRaw)
+                Log.d(TAG, msgRaw)
                 val jsonObject = JSONObject(msgRaw)
                 if (jsonObject.getString("type") == BroadcastMessageTypes.BROADCAST_LEDGER.toString()) {
                     val username = jsonObject.getString("username")

--- a/app/src/main/java/com/example/masterproject/MulticastServer.kt
+++ b/app/src/main/java/com/example/masterproject/MulticastServer.kt
@@ -1,11 +1,16 @@
 package com.example.masterproject
 
 import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 import java.lang.Exception
 import java.net.DatagramPacket
 import java.net.InetAddress
 import java.net.MulticastSocket
+import com.example.masterproject.Ledger.Companion.availableDevices
+
 
 
 class MulticastServer(private val multicastGroup: String, private val multicastPort: Int): Runnable {
@@ -14,27 +19,23 @@ class MulticastServer(private val multicastGroup: String, private val multicastP
 
     private fun listenForDevices(): MutableList<LedgerEntry>? {
         val address = InetAddress.getByName(multicastGroup);
-        val buf = ByteArray(512)
+        val buf = ByteArray(2048)
         try{
             val clientSocket = MulticastSocket(multicastPort);
             clientSocket.joinGroup(address)
 
             while (true) {
                 val msgPacket = DatagramPacket(buf, buf.size)
-                clientSocket.receive(msgPacket);
+                clientSocket.receive(msgPacket)
 
                 val msgRaw = String(buf, 0, buf.size)
-                Log.d(TAG, msgRaw)
+                Log.d(TAG, "msgRaw $msgRaw")
                 val jsonObject = JSONObject(msgRaw)
-                if (jsonObject.getString("type") == BroadcastMessageTypes.BROADCAST_LEDGER.toString()) {
-                    val username = jsonObject.getString("username")
-                    val certificateString = jsonObject.getString("certificate")
-                    val ipAddress = jsonObject.getString("ipAddress")
-                    val ledgerEntry = LedgerEntry(Utils.stringToCertificate(certificateString), username, ipAddress)
-
-                    if(isAddEntryToLedger(ledgerEntry)){
-                        Ledger.availableDevices.add(ledgerEntry)
-                    }
+                Log.d(TAG, "object ${jsonObject.toString()}")
+                when (jsonObject.getString("type")) {
+                    BroadcastMessageTypes.BROADCAST_BLOCK.toString() -> handleBroadcastedBlock(jsonObject)
+                    BroadcastMessageTypes.REQUEST_LEDGER.toString() -> handleRequestedLedger(jsonObject)
+                    BroadcastMessageTypes.FULL_LEDGER.toString() -> handleFullLedger(jsonObject)
                 }
             }
         }catch (e: Exception){
@@ -43,12 +44,40 @@ class MulticastServer(private val multicastGroup: String, private val multicastP
         return null;
     }
 
+    private fun handleBroadcastedBlock(jsonObject: JSONObject) {
+        val username = jsonObject.getString("username")
+        val certificateString = jsonObject.getString("certificate")
+        val ipAddress = jsonObject.getString("ipAddress")
+        val ledgerEntry = LedgerEntry(Utils.stringToCertificate(certificateString), username, ipAddress)
+
+        if(isAddEntryToLedger(ledgerEntry)){
+            Ledger.availableDevices.add(ledgerEntry)
+        }
+    }
+
+    private fun handleRequestedLedger(jsonObject: JSONObject) {
+        val multicastClient = MulticastClient(multicastGroup, multicastPort)
+        GlobalScope.launch (Dispatchers.IO) {
+            multicastClient.sendLedger()
+        }
+    }
+
+    private fun handleFullLedger(jsonObject: JSONObject) {
+        val ledger = jsonObject.getString("ledger")
+        val ledgerWithoutBrackets = ledger.substring(1, ledger.length - 1)
+        if (ledgerWithoutBrackets.isNotEmpty()) {
+            // split between array objects
+            val ledgerArray = ledgerWithoutBrackets.split("},{")
+            ledgerArray.forEach{
+                val ledgerEntry = LedgerEntry.parseString(it)
+                if (isAddEntryToLedger(ledgerEntry)) availableDevices.add(ledgerEntry)
+            }
+        }
+    }
+
     private fun isAddEntryToLedger(ledgerEntry: LedgerEntry): Boolean {
         //check on both username and ip. Can remove ip when proper user registration
-        val users = mutableListOf<String>()
-        for(ledgerEntry in Ledger.availableDevices){
-            users.add(ledgerEntry.userName)
-        }
+        val users = availableDevices.map { it.userName }
         return !users.contains(ledgerEntry.userName)
     }
 


### PR DESCRIPTION
- Broadcast your own ledger entry as soon as mainactivity is started.
- Request full ledger from all other users in the network as soon as mainactivity is started.
- All users respond with full ledger in response to ledger requests.
- Listen to responses to ledger request and add all new entries to your own ledger.
- Stop broadcasting your own ledger every two seconds.